### PR TITLE
Update FS extra to avoid 'experimental promise support' warnings

### DIFF
--- a/lib/unit.coffee
+++ b/lib/unit.coffee
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ###
 
 Promise = require('bluebird')
-fs = Promise.promisifyAll(require('fs-extra'))
+fs = require('fs-extra')
 _ = require('lodash')
 utils = require('./utils')
 temporal = require('./temporal')

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bluebird": "^2.9.34",
     "bluebird-queue": "0.0.7",
     "chalk": "^1.1.0",
-    "fs-extra": "^0.22.1",
+    "fs-extra": "^6.0.1",
     "lodash": "^3.10.0",
     "tmp": "0.0.26"
   }


### PR DESCRIPTION
With changes in Node 10, old versions of fs-extra now log an error to stderr when required. This breaks all Wary tests running in Appveyor (which fails builds with stderr output) for Node 10 e.g. https://github.com/resin-io-modules/resin-settings-client/pull/53

That was fixed in fs-extra 6.0.1 in https://github.com/jprichardson/node-fs-extra/pull/578. Full changelog: https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md. I don't think there's many relevant differences (except for promisification no longer being necessary), and the tests here and in resin-settings-config certainly still pass with this change.